### PR TITLE
Remove notifications from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,3 @@ script: ./autogen.sh && ./configure && make
 compiler:
   - clang
   - gcc
-
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#icecast-mentors"
-    on_success: change
-    on_failure: always
-    template:
-      - "%{repository_slug}#%{build_number} (%{branch} - %{commit} : %{author}): %{message}"
-      - "Build details : %{build_url}"


### PR DESCRIPTION
Every time you make commits this causes notifications in our IRC channel, to avoid this, remove the notifications section.